### PR TITLE
Update a-close.ftl

### DIFF
--- a/vertigo-struts2/src/main/resources/io/vertigo/struts2/ftl/template/xhtml/a-close.ftl
+++ b/vertigo-struts2/src/main/resources/io/vertigo/struts2/ftl/template/xhtml/a-close.ftl
@@ -25,7 +25,7 @@
 <#include "/${parameters.templateDir}/${parameters.expandTheme}/scripting-events.ftl" />
 <#include "/${parameters.templateDir}/${parameters.expandTheme}/common-attributes.ftl" />
 <#include "/${parameters.templateDir}/${parameters.expandTheme}/dynamic-attributes.ftl" />
->${parameters.body}</a>
+>${tag.escapeHtmlBody()?then(parameters.body, parameters.body?no_esc)}</a>
 <#if parameters.dynamicAttributes.get('tooltipPosition')?? && parameters.dynamicAttributes.get('tooltipPosition') = 'field'>
         <#include "/${parameters.templateDir}/xhtml/tooltip.ftl" /> 
 </#if>


### PR DESCRIPTION
Adaptation a-close.ftl pour struts2 v6 avec tag.escapeHtmlBody()