### PR TITLE
text.ftl avec no_esc

### DIFF
--- a/vertigo-struts2/src/main/resources/io/vertigo/struts2/ftl/template/simple_read/text.ftl
+++ b/vertigo-struts2/src/main/resources/io/vertigo/struts2/ftl/template/simple_read/text.ftl
@@ -17,6 +17,10 @@
 <#include "/${parameters.templateDir}/simple/dynamic-attributes.ftl" />
 ><#t/>
 <#if parameters.nameValue??>
- ${parameters.nameValue?replace("\n", "<br/>")}<#t/>
+  <#if parameters.escape??>
+    ${parameters.nameValue}<#t/>
+  <#else>
+    ${parameters.nameValue?replace("\n", "<br/>")?no_esc}<#t/>
+  </#if>
 </#if>
 </span><#t/>


### PR DESCRIPTION
Ajout no_esc pour <s:textfield> afin que les <br/> générés soit bien affichés